### PR TITLE
Add css property in Options for validation

### DIFF
--- a/epub.ts
+++ b/epub.ts
@@ -99,8 +99,10 @@ export class EPub {
   }
 
   protected async generateTemplateFiles() {
-    const css = await fetchFileContent("template.css");
-
+    let css = await fetchFileContent("template.css");
+    if(this.options.css){
+      css = css + this.options.css
+    }
     this.zip.addFile("OEBPS/style.css", css);
 
     for (const chapter of this.content) {

--- a/util/validate.ts
+++ b/util/validate.ts
@@ -35,6 +35,7 @@ export type Options = {
   prependChapterTitles?: boolean;
   date?: string;
   lang?: string;
+  css?: string;
   fonts?: Font[];
   version?: number;
   fetchTimeout?: number;


### PR DESCRIPTION
As mentioned by owner, it is wrapper of epub-gen-memory, by adding "css" field in option would make it work.